### PR TITLE
fix: two different `dot-pulse` colors at the same page

### DIFF
--- a/sass/_dot-pulse.scss
+++ b/sass/_dot-pulse.scss
@@ -14,8 +14,8 @@ $x3: -$left-pos + $dot-spacing;
   left: $left-pos;
 
   @include dot;
-
-  box-shadow: $x2 0 0 -5px $dot-color;
+  color: $dot-color;
+  box-shadow: $x2 0 0 -5px;
   animation: dot-pulse 1.5s infinite linear;
   animation-delay: .25s;
 
@@ -30,13 +30,15 @@ $x3: -$left-pos + $dot-spacing;
   }
 
   &::before {
-    box-shadow: $x1 0 0 -5px $dot-before-color;
+    color: $dot-before-color;
+    box-shadow: $x1 0 0 -5px;
     animation: dot-pulse-before 1.5s infinite linear;
     animation-delay: 0s;
   }
 
   &::after {
-    box-shadow: $x3 0 0 -5px $dot-after-color;
+    color: $dot-after-color;
+    box-shadow: $x3 0 0 -5px;
     animation: dot-pulse-after 1.5s infinite linear;
     animation-delay: .5s;
   }
@@ -44,45 +46,45 @@ $x3: -$left-pos + $dot-spacing;
 
 @keyframes dot-pulse-before {
   0% {
-    box-shadow: $x1 0 0 -5px $dot-before-color;
+    box-shadow: $x1 0 0 -5px;
   }
 
   30% {
-    box-shadow: $x1 0 0 2px $dot-before-color;
+    box-shadow: $x1 0 0 2px;
   }
 
   60%,
   100% {
-    box-shadow: $x1 0 0 -5px $dot-before-color;
+    box-shadow: $x1 0 0 -5px;
   }
 }
 
 @keyframes dot-pulse {
   0% {
-    box-shadow: $x2 0 0 -5px $dot-color;
+    box-shadow: $x2 0 0 -5px;
   }
 
   30% {
-    box-shadow: $x2 0 0 2px $dot-color;
+    box-shadow: $x2 0 0 2px;
   }
 
   60%,
   100% {
-    box-shadow: $x2 0 0 -5px $dot-color;
+    box-shadow: $x2 0 0 -5px;
   }
 }
 
 @keyframes dot-pulse-after {
   0% {
-    box-shadow: $x3 0 0 -5px $dot-after-color;
+    box-shadow: $x3 0 0 -5px;
   }
 
   30% {
-    box-shadow: $x3 0 0 2px $dot-after-color;
+    box-shadow: $x3 0 0 2px;
   }
 
   60%,
   100% {
-    box-shadow: $x3 0 0 -5px $dot-after-color;
+    box-shadow: $x3 0 0 -5px;
   }
 }


### PR DESCRIPTION
This is a fix for #14 

I have changed the definition of `box-shadow` to not define color, but use CSS `color` property instead.
According to W3 docs https://www.w3.org/TR/css-backgrounds-3/#box-shadow:

> `<color>`
> Specifies the color of the shadow. If the color is absent, it defaults to currentColor.
